### PR TITLE
feat: add meditation stats card to Hub

### DIFF
--- a/app/app/api/hub/route.ts
+++ b/app/app/api/hub/route.ts
@@ -183,6 +183,17 @@ export async function GET() {
               cta: "Open Reflect",
             };
 
+    // Meditation stats
+    const meditateStreak = getStreak(signals, "meditate");
+    const thirtyDaysAgo = daysAgoStr(30);
+    const meditateSessions = signals.filter(
+      (e) => e.signal === "meditate" && e.value === "1" && e.date >= thirtyDaysAgo
+    );
+    const recentMeditations = meditateSessions
+      .sort((a, b) => b.date.localeCompare(a.date))
+      .slice(0, 3)
+      .map((e) => ({ date: e.date, context: e.context || "" }));
+
     return NextResponse.json({
       nowWindow: getNowWindow(),
       gymToday,
@@ -228,6 +239,11 @@ export async function GET() {
       habitTrends,
       nextAction,
       ideas: { total: ideaCount, shipped: ideaShipped, pending: ideaPending },
+      meditation: {
+        streak: meditateStreak,
+        sessions30d: meditateSessions.length,
+        recent: recentMeditations,
+      },
     });
   } catch (e) {
     console.error("GET /api/hub error:", e);

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -56,6 +56,11 @@ interface AppData {
   habitTrends: Record<string, { date: string; value: boolean | null }[]>;
   nextAction: NextAction;
   ideas: { total: number; shipped: number; pending: number };
+  meditation: {
+    streak: number;
+    sessions30d: number;
+    recent: { date: string; context: string }[];
+  };
 }
 
 const HABIT_ORDER = [
@@ -296,6 +301,25 @@ export default function Home() {
                 </div>
               </div>
             </Link>
+          )}
+
+          {(data.meditation.streak > 0 || data.meditation.sessions30d > 0) && (
+            <section className="p-4 bg-zinc-900/60 backdrop-blur-md border border-white/10 rounded-xl">
+              <p className="text-xs text-zinc-400 uppercase">Meditation</p>
+              <div className="flex items-end justify-between mt-2">
+                <p className="text-2xl font-semibold text-zinc-100">
+                  {data.meditation.streak}d streak
+                </p>
+                <p className="text-xs text-zinc-400">
+                  {data.meditation.sessions30d} sessions / 30d
+                </p>
+              </div>
+              {data.meditation.recent.length > 0 && data.meditation.recent[0].context && (
+                <p className="mt-2 text-sm text-zinc-400 line-clamp-2">
+                  {data.meditation.recent[0].context}
+                </p>
+              )}
+            </section>
           )}
 
           <DailyInsight data={data.insight} />


### PR DESCRIPTION
## Why this makes the app better
**Execute + Reflect** — Surfacing meditation stats prominently encourages daily practice and makes session context visible for reflection.

## Layer impact
① Data:    no change — reads existing `meditate` signals from daily_signals.csv
② Logic:   `api/hub/route.ts` — compute meditation streak, 30-day session count, recent sessions with context
③ Surface: `page.tsx` — meditation card on Hub (streak, frequency, last session notes)

## What changed
- `app/app/api/hub/route.ts`: Added meditation stats computation (streak via `getStreak`, 30-day session filter, recent sessions with context) and included in API response
- `app/app/page.tsx`: Added `meditation` type to AppData interface, added meditation card between Ideas and DailyInsight sections — shows streak, 30d session count, and most recent session context. Card only renders when meditation data exists.

## Risk
**small** — Read-only addition to Hub using existing signal data; no schema changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)