### PR TITLE
feat: data-driven Vision tab with per-domain direction signals

### DIFF
--- a/app/app/api/vision/route.ts
+++ b/app/app/api/vision/route.ts
@@ -1,0 +1,244 @@
+import { NextResponse } from "next/server";
+import { daysAgoStr } from "../../lib/utils";
+import {
+  readDailySignals,
+  readReflections,
+  getStreak,
+  type DailySignalEntry,
+  type ReflectionEntry,
+} from "../../lib/csv";
+
+type Direction = "up" | "down" | "flat" | "no-data";
+
+interface DomainSystem {
+  habit: string;
+  label: string;
+  adherence14d: number;
+  streak: number;
+}
+
+interface DomainStatus {
+  id: string;
+  label: string;
+  hex: string;
+  vision: string;
+  direction: Direction;
+  systems: DomainSystem[];
+  gaps: string[];
+  recentReflection: { win: string; lesson: string; change: string } | null;
+  reflectionCount7d: number;
+}
+
+const DOMAIN_META: {
+  id: string;
+  label: string;
+  hex: string;
+  vision: string;
+  habits: { signal: string; label: string }[];
+  idealGaps: string[];
+}[] = [
+  {
+    id: "health",
+    label: "Health",
+    hex: "#10b981",
+    vision: "200 lbs lean, consistent training, clean eating as default",
+    habits: [
+      { signal: "gym", label: "Gym" },
+      { signal: "ate_clean", label: "Ate Clean" },
+    ],
+    idealGaps: ["Weight logging", "Meal tracking"],
+  },
+  {
+    id: "addiction",
+    label: "Addiction",
+    hex: "#ef4444",
+    vision: "Default sober identity. Stress response = action not numbing",
+    habits: [
+      { signal: "weed", label: "No Weed" },
+      { signal: "lol", label: "No LoL" },
+      { signal: "poker", label: "No Poker" },
+      { signal: "clarity", label: "Clarity" },
+    ],
+    idealGaps: ["Trigger journaling"],
+  },
+  {
+    id: "mental",
+    label: "Mental",
+    hex: "#818cf8",
+    vision: "Equanimity as default. Deep understanding of my mind",
+    habits: [
+      { signal: "sleep", label: "Sleep" },
+      { signal: "meditate", label: "Meditate" },
+    ],
+    idealGaps: ["Mood tracking", "Journal consistency"],
+  },
+  {
+    id: "career",
+    label: "Career",
+    hex: "#3b82f6",
+    vision: "Known for something specific. Working with people I admire",
+    habits: [{ signal: "deep_work", label: "Deep Work" }],
+    idealGaps: ["Visibility actions", "Networking cadence"],
+  },
+  {
+    id: "relationships",
+    label: "Relationships",
+    hex: "#ec4899",
+    vision: "Close the distance with Basia. 3+ local friends I see weekly",
+    habits: [],
+    idealGaps: ["Partner check-in tracking", "Social plans logging"],
+  },
+  {
+    id: "finances",
+    label: "Finances",
+    hex: "#f59e0b",
+    vision: "Clear money-to-meaning link. NW trajectory to 10M by 40",
+    habits: [],
+    idealGaps: ["Spending tracking", "Monthly review ritual"],
+  },
+  {
+    id: "fun",
+    label: "Fun",
+    hex: "#14b8a6",
+    vision: "Regular social activities I look forward to. Hobbies that compound",
+    habits: [],
+    idealGaps: ["Hobby logging", "Social event planning"],
+  },
+  {
+    id: "personal_growth",
+    label: "Growth",
+    hex: "#a855f7",
+    vision: "Clear personal philosophy written. Teaching what I know",
+    habits: [],
+    idealGaps: ["Reading tracking", "Learning log"],
+  },
+];
+
+function computeAdherence(
+  signals: DailySignalEntry[],
+  habit: string,
+  dates: string[]
+): number {
+  const logged = dates.filter((d) =>
+    signals.some((s) => s.date === d && s.signal === habit)
+  );
+  if (logged.length === 0) return 0;
+  const done = logged.filter((d) =>
+    signals.some((s) => s.date === d && s.signal === habit && s.value === "1")
+  );
+  return Math.round((done.length / logged.length) * 100);
+}
+
+function computeDirection(
+  signals: DailySignalEntry[],
+  habits: string[],
+  reflections: ReflectionEntry[],
+  domainId: string
+): Direction {
+  if (habits.length === 0) {
+    // For domains without habits, use reflection frequency
+    const recent7 = reflections.filter(
+      (r) => r.date >= daysAgoStr(7) && r.domain === domainId
+    ).length;
+    const prev7 = reflections.filter(
+      (r) =>
+        r.date >= daysAgoStr(14) &&
+        r.date < daysAgoStr(7) &&
+        r.domain === domainId
+    ).length;
+    if (recent7 === 0 && prev7 === 0) return "no-data";
+    if (recent7 > prev7) return "up";
+    if (recent7 < prev7) return "down";
+    return "flat";
+  }
+
+  const recent7Dates = Array.from({ length: 7 }, (_, i) => daysAgoStr(i));
+  const prev7Dates = Array.from({ length: 7 }, (_, i) => daysAgoStr(i + 7));
+
+  let recentTotal = 0;
+  let prevTotal = 0;
+
+  for (const habit of habits) {
+    recentTotal += computeAdherence(signals, habit, recent7Dates);
+    prevTotal += computeAdherence(signals, habit, prev7Dates);
+  }
+
+  const recentAvg = recentTotal / habits.length;
+  const prevAvg = prevTotal / habits.length;
+
+  if (recentAvg === 0 && prevAvg === 0) return "no-data";
+  const diff = recentAvg - prevAvg;
+  if (diff > 10) return "up";
+  if (diff < -10) return "down";
+  return "flat";
+}
+
+export async function GET() {
+  try {
+    const signals = readDailySignals();
+    const reflections = readReflections();
+    const last14d = Array.from({ length: 14 }, (_, i) => daysAgoStr(i));
+
+    const domains: DomainStatus[] = DOMAIN_META.map((meta) => {
+      const systems: DomainSystem[] = meta.habits.map((h) => ({
+        habit: h.signal,
+        label: h.label,
+        adherence14d: computeAdherence(signals, h.signal, last14d),
+        streak: getStreak(signals, h.signal),
+      }));
+
+      const habitSignals = meta.habits.map((h) => h.signal);
+      const direction = computeDirection(
+        signals,
+        habitSignals,
+        reflections,
+        meta.id
+      );
+
+      // Gaps: ideal systems not yet tracked via habits
+      const gaps = meta.idealGaps.filter((gap) => {
+        // If the domain has active habits with >0% adherence, remove "obvious" gaps
+        const hasActiveSystem = systems.some((s) => s.adherence14d > 0);
+        if (!hasActiveSystem) return true;
+        // Keep gaps that represent things beyond habit tracking
+        return true;
+      });
+
+      // Most recent reflection for this domain
+      const domainReflections = reflections
+        .filter((r) => r.domain === meta.id && r.archived !== "1")
+        .sort((a, b) => b.date.localeCompare(a.date));
+      const latest = domainReflections[0] || null;
+      const recentReflection = latest
+        ? { win: latest.win, lesson: latest.lesson, change: latest.change }
+        : null;
+
+      const reflectionCount7d = reflections.filter(
+        (r) =>
+          r.domain === meta.id &&
+          r.date >= daysAgoStr(7) &&
+          r.archived !== "1"
+      ).length;
+
+      return {
+        id: meta.id,
+        label: meta.label,
+        hex: meta.hex,
+        vision: meta.vision,
+        direction,
+        systems,
+        gaps,
+        recentReflection,
+        reflectionCount7d,
+      };
+    });
+
+    return NextResponse.json({ domains });
+  } catch (e) {
+    console.error("GET /api/vision error:", e);
+    return NextResponse.json(
+      { error: "Failed to load vision data" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/app/vision/page.tsx
+++ b/app/app/vision/page.tsx
@@ -1,373 +1,225 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 // ── Types ───────────────────────────────────────────────────────────
 
-type Dimension = {
+interface DomainSystem {
+  habit: string;
+  label: string;
+  adherence14d: number;
+  streak: number;
+}
+
+type Direction = "up" | "down" | "flat" | "no-data";
+
+interface DomainStatus {
   id: string;
   label: string;
-  satisfaction: number;
-  alignment: number;
   hex: string;
-  notes: string;
-  goals: {
-    week: string[];
-    month: string[];
-    year: string[];
-  };
+  vision: string;
+  direction: Direction;
+  systems: DomainSystem[];
+  gaps: string[];
+  recentReflection: { win: string; lesson: string; change: string } | null;
+  reflectionCount7d: number;
+}
+
+interface VisionData {
+  domains: DomainStatus[];
+}
+
+// ── Direction helpers ───────────────────────────────────────────────
+
+const DIRECTION_ICON: Record<Direction, string> = {
+  up: "\u2191",
+  down: "\u2193",
+  flat: "\u2192",
+  "no-data": "\u2013",
 };
 
-// ── Data ────────────────────────────────────────────────────────────
+const DIRECTION_COLOR: Record<Direction, string> = {
+  up: "text-emerald-400",
+  down: "text-red-400",
+  flat: "text-zinc-400",
+  "no-data": "text-zinc-600",
+};
 
-const DIMENSIONS: Dimension[] = [
-  {
-    id: "health",
-    label: "Health",
-    satisfaction: 3,
-    alignment: 5,
-    hex: "#10b981",
-    notes: "Gym habit sticky, eating is weak link especially traveling. More green days recently.",
-    goals: {
-      week: ["Hit all scheduled lifts", "Eat clean 5/7 days"],
-      month: ["No missed gym weeks", "Consistent meal prep routine"],
-      year: ["200 lbs lean", "Run 2x/week habit locked"],
-    },
-  },
-  {
-    id: "addiction",
-    label: "Addiction",
-    satisfaction: 4,
-    alignment: 6,
-    hex: "#ef4444",
-    notes: "Weed streak building. Routine changes and stress break things. Awareness is high.",
-    goals: {
-      week: ["Maintain streak", "Log triggers when they hit"],
-      month: ["30-day clean streak", "Identify top 3 trigger patterns"],
-      year: ["Default sober identity", "Stress response = action not numbing"],
-    },
-  },
-  {
-    id: "career",
-    label: "Career",
-    satisfaction: 5,
-    alignment: 5,
-    hex: "#3b82f6",
-    notes: "Doing the work but closed off in room. Not in spaces where opportunities compound.",
-    goals: {
-      week: ["Ship one meaningful thing", "One conversation outside team"],
-      month: ["Visible output that others reference", "Attend 1 in-person event"],
-      year: ["Known for something specific", "Working with people I admire"],
-    },
-  },
-  {
-    id: "relationships",
-    label: "Relationships",
-    satisfaction: 3,
-    alignment: 5,
-    hex: "#ec4899",
-    notes: "Basia: long-distance, plan to close gap. Need positive-sum friendships. Family strong.",
-    goals: {
-      week: ["Quality call with Basia", "Reach out to one friend"],
-      month: ["Visit or host someone", "One new recurring social thing"],
-      year: ["Close the distance", "3+ local friends I see weekly"],
-    },
-  },
-  {
-    id: "growth",
-    label: "Growth",
-    satisfaction: 5,
-    alignment: 7,
-    hex: "#a855f7",
-    notes: "Personal OS creating daily insights. Direction right, accelerating.",
-    goals: {
-      week: ["Daily reflection logged", "Read 30 min"],
-      month: ["Finish one book", "One system improvement shipped"],
-      year: ["Clear personal philosophy written", "Teaching what I know"],
-    },
-  },
-  {
-    id: "finances",
-    label: "Finances",
-    satisfaction: 6,
-    alignment: 6,
-    hex: "#f59e0b",
-    notes: "200k income, 600k NW. On a path but vision unclear on why.",
-    goals: {
-      week: ["Track spending", "No impulse purchases"],
-      month: ["Investment contribution on schedule", "Review budget"],
-      year: ["Clear money-to-meaning link", "NW trajectory to 10M by 40"],
-    },
-  },
-  {
-    id: "fun",
-    label: "Fun",
-    satisfaction: 6,
-    alignment: 4,
-    hex: "#14b8a6",
-    notes: "Poker is fun but zero-sum. Want positive-sum hobbies that build relationships.",
-    goals: {
-      week: ["One fun thing that isn't solo", "Try something new"],
-      month: ["Find one positive-sum hobby", "Weekend plans 3/4 weeks"],
-      year: ["Regular social activities I look forward to", "Hobbies that compound"],
-    },
-  },
-  {
-    id: "mental",
-    label: "Mental",
-    satisfaction: 4,
-    alignment: 5,
-    hex: "#818cf8",
-    notes: "Meditation is the lever. Mental stability tracks sleep + meditation + fast interruption loops.",
-    goals: {
-      week: ["Meditate daily", "Journal 3x"],
-      month: ["No multi-day spirals", "Sleep 7h+ average"],
-      year: ["Equanimity as default", "Deep understanding of my mind"],
-    },
-  },
-];
+const DIRECTION_LABEL: Record<Direction, string> = {
+  up: "Improving",
+  down: "Declining",
+  flat: "Steady",
+  "no-data": "No data",
+};
 
-// ── Radar helpers ───────────────────────────────────────────────────
+// ── Domain Card ─────────────────────────────────────────────────────
 
-const CX = 150;
-const CY = 150;
-const MAX_R = 120;
-const N = DIMENSIONS.length;
-
-function polarToXY(angle: number, r: number): [number, number] {
-  const rad = ((angle - 90) * Math.PI) / 180;
-  return [CX + r * Math.cos(rad), CY + r * Math.sin(rad)];
-}
-
-function dimAngle(i: number): number {
-  return (360 / N) * i;
-}
-
-function polygonPoints(values: number[]): string {
-  return values
-    .map((v, i) => {
-      const r = (v / 10) * MAX_R;
-      const [x, y] = polarToXY(dimAngle(i), r);
-      return `${x},${y}`;
-    })
-    .join(" ");
-}
-
-function gridOctagon(scale: number): string {
-  const r = (scale / 10) * MAX_R;
-  return Array.from({ length: N }, (_, i) => {
-    const [x, y] = polarToXY(dimAngle(i), r);
-    return `${x},${y}`;
-  }).join(" ");
-}
-
-function wedgePath(i: number): string {
-  const a1 = dimAngle(i) - 360 / N / 2;
-  const a2 = dimAngle(i) + 360 / N / 2;
-  const [x1, y1] = polarToXY(a1, MAX_R + 35);
-  const [x2, y2] = polarToXY(a2, MAX_R + 35);
-  return `M ${CX} ${CY} L ${x1} ${y1} A ${MAX_R + 35} ${MAX_R + 35} 0 0 1 ${x2} ${y2} Z`;
-}
-
-// ── Radar Chart ─────────────────────────────────────────────────────
-
-function RadarChart({
-  selected,
-  onSelect,
+function DomainCard({
+  domain,
+  expanded,
+  onToggle,
 }: {
-  selected: string | null;
-  onSelect: (id: string | null) => void;
+  domain: DomainStatus;
+  expanded: boolean;
+  onToggle: () => void;
 }) {
-  const satPoints = polygonPoints(DIMENSIONS.map((d) => d.satisfaction));
-  const alignPoints = polygonPoints(DIMENSIONS.map((d) => d.alignment));
+  const hasSystems = domain.systems.length > 0;
+  const hasGaps = domain.gaps.length > 0;
 
-  return (
-    <div className="flex flex-col items-center">
-      <svg viewBox="0 0 300 300" className="w-full max-w-[320px] sm:max-w-[380px]">
-        {[2, 4, 6, 8, 10].map((s) => (
-          <polygon
-            key={s}
-            points={gridOctagon(s)}
-            fill="none"
-            stroke="rgba(255,255,255,0.06)"
-            strokeWidth="0.5"
-          />
-        ))}
-
-        {DIMENSIONS.map((_, i) => {
-          const [x, y] = polarToXY(dimAngle(i), MAX_R + 5);
-          return (
-            <line
-              key={i}
-              x1={CX}
-              y1={CY}
-              x2={x}
-              y2={y}
-              stroke="rgba(255,255,255,0.06)"
-              strokeWidth="0.5"
-            />
-          );
-        })}
-
-        <polygon
-          points={alignPoints}
-          fill="rgba(168,85,247,0.08)"
-          stroke="rgba(168,85,247,0.4)"
-          strokeWidth="1.5"
-          strokeDasharray="4 2"
-        />
-        <polygon
-          points={satPoints}
-          fill="rgba(59,130,246,0.12)"
-          stroke="rgba(59,130,246,0.6)"
-          strokeWidth="1.5"
-        />
-
-        {DIMENSIONS.map((d, i) => {
-          const angle = dimAngle(i);
-          const satR = (d.satisfaction / 10) * MAX_R;
-          const [sx, sy] = polarToXY(angle, satR);
-          const alignR = (d.alignment / 10) * MAX_R;
-          const [ax, ay] = polarToXY(angle, alignR);
-          const [lx, ly] = polarToXY(angle, MAX_R + 22);
-          const isSelected = selected === d.id;
-
-          return (
-            <g key={d.id}>
-              <circle
-                cx={sx}
-                cy={sy}
-                r={isSelected ? 4.5 : 3}
-                fill={isSelected ? d.hex : "rgba(59,130,246,0.8)"}
-                className="transition-all duration-200"
-              />
-              <circle
-                cx={ax}
-                cy={ay}
-                r={isSelected ? 4.5 : 3}
-                fill="none"
-                stroke={isSelected ? d.hex : "rgba(168,85,247,0.6)"}
-                strokeWidth="1.5"
-                className="transition-all duration-200"
-              />
-              <text
-                x={lx}
-                y={ly}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill={isSelected ? d.hex : "rgba(161,161,170,0.7)"}
-                fontSize={isSelected ? "10" : "9"}
-                fontWeight={isSelected ? "600" : "400"}
-                className="transition-all duration-200"
-              >
-                {d.label}
-              </text>
-              <text
-                x={lx}
-                y={ly + 11}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill={isSelected ? "rgba(255,255,255,0.7)" : "rgba(161,161,170,0.4)"}
-                fontSize="8"
-              >
-                {d.satisfaction}/{d.alignment}
-              </text>
-              <path
-                d={wedgePath(i)}
-                fill="transparent"
-                className="cursor-pointer"
-                onClick={() => onSelect(selected === d.id ? null : d.id)}
-              />
-            </g>
-          );
-        })}
-
-        <text x={CX} y={CY - 4} textAnchor="middle" fill="rgba(161,161,170,0.5)" fontSize="9" fontWeight="500">
-          ASH
-        </text>
-        <text x={CX} y={CY + 8} textAnchor="middle" fill="rgba(161,161,170,0.3)" fontSize="7">
-          sat / align
-        </text>
-      </svg>
-
-      <div className="flex items-center gap-4 mt-2 text-[10px] text-zinc-500">
-        <span className="flex items-center gap-1">
-          <span className="w-2.5 h-0.5 bg-blue-500/60 rounded inline-block" /> Satisfaction
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="w-2.5 h-0.5 border border-purple-500/60 rounded inline-block border-dashed" /> Alignment
-        </span>
-      </div>
-    </div>
-  );
-}
-
-// ── Goals Panel ─────────────────────────────────────────────────────
-
-const HORIZONS = ["week", "month", "year"] as const;
-const HORIZON_LABELS: Record<string, string> = {
-  week: "This Week",
-  month: "This Month",
-  year: "This Year",
-};
-
-function GoalsPanel({ dimension }: { dimension: Dimension }) {
   return (
     <div
-      className="rounded-xl border bg-zinc-900/60 p-4 transition-all duration-200"
-      style={{ borderColor: `${dimension.hex}33` }}
+      className="rounded-xl border bg-zinc-900/60 p-4 transition-all duration-200 cursor-pointer"
+      style={{ borderColor: expanded ? `${domain.hex}44` : "rgba(255,255,255,0.05)" }}
+      onClick={onToggle}
     >
-      <div className="flex items-center gap-2 mb-3">
-        <span className="w-2 h-2 rounded-full" style={{ backgroundColor: dimension.hex }} />
-        <h3 className="text-sm font-semibold text-zinc-100">{dimension.label}</h3>
-        <span className="text-xs text-zinc-500 ml-auto">{dimension.satisfaction}/{dimension.alignment}</span>
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <span
+          className="w-2.5 h-2.5 rounded-full shrink-0"
+          style={{ backgroundColor: domain.hex }}
+        />
+        <h3 className="text-sm font-semibold text-zinc-100 flex-1">
+          {domain.label}
+        </h3>
+        <span
+          className={`text-lg font-bold ${DIRECTION_COLOR[domain.direction]}`}
+          title={DIRECTION_LABEL[domain.direction]}
+        >
+          {DIRECTION_ICON[domain.direction]}
+        </span>
       </div>
 
-      <p className="text-xs text-zinc-400 mb-4">{dimension.notes}</p>
+      {/* Vision statement */}
+      <p className="text-xs text-zinc-500 mt-1.5 ml-[22px]">{domain.vision}</p>
 
-      <div className="grid grid-cols-3 gap-3">
-        {HORIZONS.map((h) => (
-          <div key={h}>
-            <h4 className="text-[10px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
-              {HORIZON_LABELS[h]}
-            </h4>
-            <ul className="space-y-1.5">
-              {dimension.goals[h].map((g, i) => (
-                <li key={i} className="text-xs text-zinc-300 leading-relaxed">
-                  <span className="text-zinc-600 mr-1">-</span>
-                  {g}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
+      {/* Systems bar */}
+      {hasSystems && (
+        <div className="flex gap-2 mt-3 ml-[22px]">
+          {domain.systems.map((sys) => (
+            <div
+              key={sys.habit}
+              className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-800/80 text-xs"
+            >
+              <span className="text-zinc-400">{sys.label}</span>
+              <span
+                className={
+                  sys.adherence14d >= 70
+                    ? "text-emerald-400 font-medium"
+                    : sys.adherence14d >= 40
+                      ? "text-amber-400 font-medium"
+                      : "text-red-400 font-medium"
+                }
+              >
+                {sys.adherence14d}%
+              </span>
+              {sys.streak > 0 && (
+                <span className="text-zinc-600">{sys.streak}d</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* No systems indicator */}
+      {!hasSystems && (
+        <div className="mt-3 ml-[22px]">
+          <span className="text-[11px] text-zinc-600 italic">No active tracking systems</span>
+        </div>
+      )}
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="mt-4 ml-[22px] space-y-3">
+          {/* Recent reflection */}
+          {domain.recentReflection && (
+            <div className="rounded-lg bg-zinc-800/50 p-3">
+              <p className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5">
+                Latest Reflection
+              </p>
+              {domain.recentReflection.change && (
+                <p className="text-xs text-zinc-300">
+                  <span className="text-zinc-500 mr-1">Change:</span>
+                  {domain.recentReflection.change}
+                </p>
+              )}
+              {domain.recentReflection.lesson && (
+                <p className="text-xs text-zinc-300 mt-1">
+                  <span className="text-zinc-500 mr-1">Lesson:</span>
+                  {domain.recentReflection.lesson}
+                </p>
+              )}
+              {domain.recentReflection.win && (
+                <p className="text-xs text-zinc-300 mt-1">
+                  <span className="text-zinc-500 mr-1">Win:</span>
+                  {domain.recentReflection.win}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Gaps */}
+          {hasGaps && (
+            <div>
+              <p className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5">
+                Missing Systems
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {domain.gaps.map((gap) => (
+                  <span
+                    key={gap}
+                    className="text-[11px] text-zinc-500 px-2 py-0.5 rounded-md border border-zinc-800 bg-zinc-900/50"
+                  >
+                    {gap}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Reflection count */}
+          <p className="text-[11px] text-zinc-600">
+            {domain.reflectionCount7d} reflection{domain.reflectionCount7d !== 1 ? "s" : ""} this week
+          </p>
+        </div>
+      )}
     </div>
   );
 }
 
-function AllGoalsGrid() {
+// ── Summary Bar ─────────────────────────────────────────────────────
+
+function SummaryBar({ domains }: { domains: DomainStatus[] }) {
+  const up = domains.filter((d) => d.direction === "up").length;
+  const down = domains.filter((d) => d.direction === "down").length;
+  const flat = domains.filter((d) => d.direction === "flat").length;
+  const noData = domains.filter((d) => d.direction === "no-data").length;
+  const tracked = domains.filter((d) => d.systems.length > 0).length;
+
   return (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {DIMENSIONS.map((d) => (
-        <div
-          key={d.id}
-          className="rounded-xl border border-white/5 bg-zinc-900/40 p-3"
-        >
-          <div className="flex items-center gap-2 mb-2">
-            <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: d.hex }} />
-            <span className="text-xs font-medium text-zinc-300">{d.label}</span>
-            <span className="text-[10px] text-zinc-600 ml-auto">{d.satisfaction}/{d.alignment}</span>
-          </div>
-          <div className="space-y-1">
-            {d.goals.month.map((g, i) => (
-              <p key={i} className="text-[11px] text-zinc-500">
-                <span className="text-zinc-700 mr-1">-</span>{g}
-              </p>
-            ))}
-          </div>
-        </div>
-      ))}
+    <div className="flex items-center gap-4 text-xs text-zinc-400">
+      {up > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="text-emerald-400 font-bold">{up}</span> improving
+        </span>
+      )}
+      {flat > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="text-zinc-300 font-bold">{flat}</span> steady
+        </span>
+      )}
+      {down > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="text-red-400 font-bold">{down}</span> declining
+        </span>
+      )}
+      {noData > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="text-zinc-600 font-bold">{noData}</span> untracked
+        </span>
+      )}
+      <span className="text-zinc-600 ml-auto">
+        {tracked}/{domains.length} domains have systems
+      </span>
     </div>
   );
 }
@@ -375,37 +227,96 @@ function AllGoalsGrid() {
 // ── Page ────────────────────────────────────────────────────────────
 
 export default function VisionPage() {
-  const [selected, setSelected] = useState<string | null>(null);
-  const active = selected ? DIMENSIONS.find((d) => d.id === selected) ?? null : null;
+  const [data, setData] = useState<VisionData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const fetchData = useCallback(() => {
+    fetch("/api/vision")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch vision");
+        return res.json();
+      })
+      .then((d) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error("Failed to load vision:", err);
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-black text-zinc-100 flex items-center justify-center">
+        <p className="text-zinc-400">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="min-h-screen bg-black text-zinc-100 flex items-center justify-center">
+        <p className="text-red-400">Failed to load vision data</p>
+      </div>
+    );
+  }
+
+  // Sort: domains with systems first, then by direction (down > flat > up > no-data)
+  const directionPriority: Record<Direction, number> = {
+    down: 0,
+    flat: 1,
+    up: 2,
+    "no-data": 3,
+  };
+  const sorted = [...data.domains].sort((a, b) => {
+    const aHas = a.systems.length > 0 ? 0 : 1;
+    const bHas = b.systems.length > 0 ? 0 : 1;
+    if (aHas !== bHas) return aHas - bHas;
+    return directionPriority[a.direction] - directionPriority[b.direction];
+  });
 
   return (
     <div className="min-h-screen bg-black text-zinc-100">
       <div className="p-4 sm:p-6 pb-24">
-        <div className="max-w-3xl mx-auto space-y-6">
+        <div className="max-w-3xl mx-auto space-y-5">
           <div className="text-center">
             <h1 className="text-2xl sm:text-3xl font-bold mb-1">Vision</h1>
-            <p className="text-zinc-500 text-sm">Tap a dimension to see goals</p>
+            <p className="text-zinc-500 text-sm">
+              Am I going in the right direction?
+            </p>
           </div>
 
-          <RadarChart selected={selected} onSelect={setSelected} />
+          <SummaryBar domains={data.domains} />
 
-          {active ? (
-            <GoalsPanel dimension={active} />
-          ) : (
-            <AllGoalsGrid />
-          )}
+          <div className="space-y-3">
+            {sorted.map((domain) => (
+              <DomainCard
+                key={domain.id}
+                domain={domain}
+                expanded={expanded === domain.id}
+                onToggle={() =>
+                  setExpanded(expanded === domain.id ? null : domain.id)
+                }
+              />
+            ))}
+          </div>
 
           <section className="rounded-xl border border-amber-500/20 bg-amber-500/5 px-4 py-3">
             <h2 className="text-xs font-semibold text-amber-400/80 uppercase tracking-wider mb-1.5">
               Core Question
             </h2>
             <p className="text-zinc-300 text-sm leading-relaxed">
-              Trade escape for building. Move from reactive coping to intentional action
-              that compounds across health, relationships, and meaningful work.
+              Trade escape for building. Move from reactive coping to intentional
+              action that compounds across health, relationships, and meaningful
+              work.
             </p>
           </section>
-
-          <p className="text-center text-zinc-700 text-xs">Vision baseline — March 2026</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Why this makes the app better
**Reflect + Adapt** — Surfaces whether each life domain is trending in the right direction, what systems enforce the vision, and what's missing.

## Layer impact
1. Data:    no change
2. Logic:   new `/api/vision` route computes per-domain direction signals, adherence stats, and reflection summaries from existing CSVs
3. Surface: Vision page rewritten from static hardcoded data to live API-driven cards

## What changed
- `app/app/api/vision/route.ts`: New API — maps 8 domains to their tracked habits, computes 14-day adherence, 7-day direction trend (up/down/flat), surfaces gaps and latest reflections
- `app/app/vision/page.tsx`: Replaced static radar chart + hardcoded goals with expandable domain cards showing vision statement, direction arrow, system adherence badges, missing systems, and latest reflections

## Risk
small — read-only API over existing CSVs, no data mutations, fully replaces a static page

Generated with [Claude Code](https://claude.com/claude-code)